### PR TITLE
Snap: Fix crash switching from back to front cam in video mode

### DIFF
--- a/src/com/android/camera/VideoModule.java
+++ b/src/com/android/camera/VideoModule.java
@@ -3061,6 +3061,7 @@ public class VideoModule extends BaseModule<VideoUI> implements
         boolean mirror = (info.facing == CameraInfo.CAMERA_FACING_FRONT);
         mFocusManager.setMirror(mirror);
         mFocusManager.setParameters(mInitialParams);
+        readVideoPreferences();
         setCameraParameters(UPDATE_PARAM_ALL);
         startPreview();
 


### PR DESCRIPTION
E CAM_VideoModule: startPreview paused=false device=false params=false
E CAM_VideoModule: java.lang.Throwable
E CAM_VideoModule: 	at com.android.camera.VideoModule.startPreview(VideoModule.java:1324)
E CAM_VideoModule: 	at com.android.camera.VideoModule.switchCamera(VideoModule.java:3067)
E CAM_VideoModule: 	at com.android.camera.VideoModule.onCameraPickerClicked(VideoModule.java:3251)
E CAM_VideoModule: 	at com.android.camera.VideoMenu$4.onClick(VideoMenu.java:504)
E CAM_VideoModule: 	at android.view.View.performClick(View.java:5637)
E CAM_VideoModule: 	at android.view.View$PerformClick.run(View.java:22433)
E CAM_VideoModule: 	at android.os.Handler.handleCallback(Handler.java:751)
E CAM_VideoModule: 	at android.os.Handler.dispatchMessage(Handler.java:95)
E CAM_VideoModule: 	at android.os.Looper.loop(Looper.java:154)
E CAM_VideoModule: 	at android.app.ActivityThread.main(ActivityThread.java:6186)
E CAM_VideoModule: 	at java.lang.reflect.Method.invoke(Native Method)
E CAM_VideoModule: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
E CAM_VideoModule: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)

Change-Id: I2005b09737fd4d739e1415a457b05d575da95582